### PR TITLE
disp. adic.: reintegración efectiva del Derecho Civil valenciano

### DIFF
--- a/constitucion-espanola-1978.adoc
+++ b/constitucion-espanola-1978.adoc
@@ -1312,6 +1312,9 @@ La actualización general de dicho régimen foral se llevará a cabo, en su caso
 
 La declaración de mayoría de edad contenida en el artículo 12 de esta Constitución no perjudica las situaciones amparadas por los derechos forales en el ámbito del Derecho privado.
 
+La competencia legislativa civil de las comunidades autónomas, asumida a sus propios estatutos conforme al artículo 149.1.8.ª de la Constitución, se extenderá a la recuperación y la actualización de su derecho privado histórico de acuerdo
+con los valores y los principios constitucionales.
+
 ===== Tercera.
 
 La modificación del régimen económico y fiscal del archipiélago canario requerirá informe previo de la Comunidad Autónoma o, en su caso, del órgano provisional autonómico.


### PR DESCRIPTION
En febrero de 2020, las Corts Valencianes aprueban reclamar al Congreso una reforma constitucional para recuperar la capacidad de legislar en materia civil apoyándose en el reconocimiento de los fueros, al haber sido este terrirorio parte de la Corona de Aragón.