### PR TITLE
constitucion-78: art.43: garantizar el derecho al aborto

### DIFF
--- a/constitucion-espanola-1978.adoc
+++ b/constitucion-espanola-1978.adoc
@@ -313,6 +313,7 @@ El Estado velará especialmente por la salvaguardia de los derechos económicos 
 La ley establecerá los derechos y deberes de todos al respecto.
 3. Los poderes públicos fomentarán la educación sanitaria, la educación física y el deporte.
 Asimismo facilitarán la adecuada utilización del ocio.
+4. Los poderes públicos garantizarán el ejercicio del derecho de las mujeres a la interrupción voluntaria del embarazo en condiciones de igualdad real y efectiva con cuantas prestaciones y servicios sean necesarios para dicho ejercicio.
 
 ===== Artículo 44
 


### PR DESCRIPTION
I

En los años de vigencia de nuestra Constitución, España se ha consolidado como una sociedad democrática avanzada en el reconocimiento y garantía de los derechos fundamentales proclamados en el Título Primero de nuestra Norma Fundamental.  Sin embargo, los textos constitucionales no pueden permanecer intangibles si se quiere que continúen sirviendo con fidelidad a los objetivos que se han marcado desde su origen.  Las generaciones posteriores a la constituyente tienen el derecho y la obligación de revisar sus formulaciones, adaptándolas y mejorándolas, de cara a lograr una mayor garantía del ejercicio de los derechos que la propia Constitución proclama.  En consecuencia, el avance en el reconocimiento jurídico de los derechos y, en lo que ahora interesa, el fortalecimiento de los derechos de libertad y de autodeterminación de las mujeres, así como su protección frente a eventuales dinámicas regresivas, abogan por la incorporación en la Constitución de un mandato a los poderes públicos dirigido a garantizar el ejercicio del derecho de las mujeres a la interrupción voluntaria del embarazo que deriva del artículo 15 de la Constitución, mediante el establecimiento de las prestaciones y servicios que sean necesarios.

El derecho de la mujer a decidir libremente respecto a su proyecto de vida y, en consecuencia, su derecho a interrumpir voluntariamente el embarazo «forma parte del contenido constitucionalmente protegido del derecho fundamental a la integridad física y moral (artículo 15 CE) en conexión con la dignidad de la persona y el libre desarrollo de su personalidad como principios rectores del orden político y la paz social (artículo 10.1 CE)», tal y como afirma sin ambages el Tribunal Constitucional español en el fundamento jurídico tercero de la STC 44/2023, de 9 de mayo.

En conexión con ello, el Tribunal Constitucional también ha determinado que la interrupción voluntaria del embarazo se vincula con el derecho a la protección de la salud, reconocido en el artículo 43 de la Constitución, entendiendo que existe un deber del Estado de «garantizar que la realización del aborto se llevará a cabo dentro de los límites previstos por el legislador y en las condiciones médicas adecuadas para salvaguardar el derecho a la vida y a la salud de la mujer» (STC 53/1985, de 11 de abril, FJ 12).  Quedan así perfectamente imbricados el derecho a la interrupción voluntaria del embarazo reconocido en el artículo 15 de la Constitución con el derecho a la protección de la salud previsto en su artículo 43.1, que se concreta en el deber de los poderes públicos de «organizar y tutelar la salud pública mediante medidas preventivas y mediante las prestaciones y servicios necesarios» (artículo 43.2 CE).

El Tribunal Constitucional ha entendido que del derecho a la protección de la salud se desprende un «contenido mínimo que hace reconocible el mandato imperativo que los poderes públicos deben asegurar y prestar (artículo 43 CE) en cualquier circunstancia a cualquier persona con el fin de preservar el derecho fundamental a la vida y la integridad física contenido en el artículo 15 CE» (STC 118/2019, de 16 de octubre, FJ 4).  De ello se deriva que, en el ámbito de la interrupción voluntaria del embarazo, forman parte del derecho a la protección de la salud cuantas prestaciones sanitarias, asistenciales y de todo orden sean necesarias para garantizar que su práctica se realice en las mejores condiciones, siendo exigible su garantía a los poderes públicos, mediante el establecimiento de las prestaciones y servicios que sean necesarios.

II

Esta libertad básica de las mujeres fue perseguida penalmente durante muchos años en nuestro país, hasta que la Ley Orgánica 9/1985, de 5 de julio, de reforma del artículo 417 bis del Código Penal, despenalizó determinados supuestos de interrupción voluntaria del embarazo.  Ahora bien, fue a partir de la Ley Orgánica 2/2010, de 3 de marzo, de salud sexual y reproductiva y de la interrupción voluntaria del embarazo, cuando España se incorporó al conjunto de países más avanzados en la protección de los derechos de las mujeres, estableciendo que los poderes públicos están obligados a no interferir en estas decisiones, que corresponden exclusivamente al ámbito de autodeterminación personal de las mujeres en las primeras semanas de la gestación.  Esta ley orgánica también incorporó obligaciones vinculadas a la responsabilidad institucional de todas las administraciones públicas competentes en la garantía del libre ejercicio del derecho a la interrupción voluntaria del embarazo, y fue avalada por el Tribunal Constitucional en la mencionada Sentencia 44/2023, de 9 de mayo.

Posteriormente, la Ley Orgánica 4/2022, de 12 de abril, por la que se modifica la Ley Orgánica 10/1995, de 23 de noviembre, del Código Penal, introdujo en el Código Penal el artículo 172 quater para penalizar el acoso a las mujeres que acuden a clínicas para la interrupción voluntaria del embarazo, reforma que cuenta con el aval del Tribunal Constitucional en la Sentencia 75/2024, de 8 de mayo.  Finalmente, en virtud de la Ley Orgánica 1/2023, de 28 de febrero, por la que se modifica la Ley Orgánica 2/2010, de 3 de marzo, de salud sexual y reproductiva y de la interrupción voluntaria del embarazo, entre otras modificaciones tendentes a garantizar la vigencia efectiva de los derechos sexuales y reproductivos de las mujeres, se revirtió la modificación operada por la Ley Orgánica 11/2015, de 21 de septiembre, reconociendo de nuevo el derecho de las menores de edad de 16 y 17 años a interrumpir voluntariamente su embarazo sin necesidad de consentimiento de sus padres, tutores o representantes legales.

Por último, en el ámbito de la Unión Europea, el Parlamento Europeo aprobó el 11 de abril de 2024 la «Resolución sobre la inclusión del derecho al aborto en la Carta de los Derechos Fundamentales de la Unión Europea» [2024/2655 (RSP)], en la que insta al Consejo Europeo a que ponga en marcha una Convención para la revisión de los Tratados, tal como solicitó en sus Resoluciones de 9 de junio de 2022 y de 22 de noviembre de 2023, y a que adopte la propuesta incluida en su Resolución de 22 de noviembre de 2023 de añadir a la Carta la asistencia sanitaria sexual y reproductiva y el derecho al aborto seguro y legal.

III

Si bien el desarrollo legislativo y jurisprudencial en materia de reconocimiento y garantía de la interrupción voluntaria del embarazo ha resultado determinante para la protección de la vida, la integridad y la salud de las mujeres, la relevancia de los bienes jurídicos implicados, unida a la necesidad de reforzar la obligación de los poderes públicos de asegurar de manera real y efectiva la prestación que permite una interrupción del embarazo en condiciones de igualdad y de seguridad, exige avanzar un paso más constitucionalizando la obligación de los poderes públicos de garantizar y hacer efectivo el libre ejercicio de este derecho mediante el establecimiento de cuantas prestaciones y servicios sean necesarios.

Con este reconocimiento constitucional, el derecho a la interrupción voluntaria del embarazo queda reforzado con la obligación, indisponible para los poderes públicos, de garantizar su ejercicio en condiciones sanitarias apropiadas, estableciendo las prestaciones y servicios necesarios para tal fin.  Con esta reforma constitucional España avanza en el reconocimiento social y jurídico del derecho a la autodeterminación de las mujeres y a su necesaria protección frente a dinámicas regresivas.

En cuanto a su ubicación sistemática, la protección de la vertiente prestacional del derecho a la interrupción voluntaria del embarazo encuentra acomodo en el artículo 43 de la Constitución, que reconoce el derecho a la protección de la salud e insta a los poderes públicos a establecer las prestaciones y los servicios necesarios para tal fin.

El nuevo precepto hace hincapié en la necesidad de que los poderes públicos aseguren, en condiciones de igualdad real y efectiva y, por tanto, en todo el territorio del Estado, la garantía real del ejercicio de este derecho, mediante el establecimiento de las prestaciones sanitarias, asistenciales y de todo orden que sean necesarias para su práctica, exigencia que está inescindiblemente unida a la protección de los derechos fundamentales vinculados a dicho derecho, tal y como refleja la jurisprudencia del Tribunal Constitucional.

Con esta reforma constitucional, España se coloca a la vanguardia de los países europeos más avanzados en la protección de los derechos de las mujeres, garantizando la obligación de los poderes públicos, no solo de no interferir en la libertad de las mujeres de decidir interrumpir voluntariamente su embarazo en las primeras semanas de la gestación, que corresponde exclusivamente al ámbito de su autodeterminación personal, sino de hacerlo efectivo mediante el establecimiento de cuantas prestaciones y servicios sean necesarios para tal fin.

Iniciativa-de: Gobierno de España
Firmado-por: Gobierno de España

Referencia B.O.E.: https://www.congreso.es/es/busqueda-de-publicaciones?p_p_id=publicaciones&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_publicaciones_mode=mostrarTextoIntegro&_publicaciones_legislatura=XV&_publicaciones_id_texto=(BOCG-15-A-92-1.CODI.)